### PR TITLE
[#69] Use activity_id when creating Activities for matched user

### DIFF
--- a/api/v3/CiviOutlook.php
+++ b/api/v3/CiviOutlook.php
@@ -262,7 +262,14 @@ function civicrm_api3_civi_outlook_createactivity($params) {
       'activity_type', NULL, FALSE
       );
       if (CRM_Utils_Array::value('activity_type', $params)) {
-        $customActivityParams['activity_type_id'] = $params['activity_type'];
+        $activity_type_id = array_search($params['activity_type'], $activityOptions);
+        if (empty($activity_type_id)) {
+          // try default behavior
+          $customActivityParams['activity_type_id'] = $params['activity_type'];
+        } else {
+          $customActivityParams['activity_type_id'] = $activity_type_id;
+        }
+
       }
       else {
         $customActivityParams['activity_type_id'] = $activityTypeDefaultSetting;


### PR DESCRIPTION
Tested and verified with german translations on 3.04 and newest release of the outlook Extesion. I left the default behaviour in place in case the lookup doesn't work.